### PR TITLE
Tranform HTTP urls to HTTPS to honour the CSP

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -87,7 +87,7 @@ app.redirect = function (requestDetails) {
     // Request from this plugin itself (embedded PDF).
     return;
   }
-  var url = app.pdfviewerTarget + requestDetails.url;
+  var url = app.pdfviewerTarget + requestDetails.url.replace('http:', 'https:');
   url = chrome.runtime.getURL(url);
   console.log(app.name, "Redirecting: " + requestDetails.url + " to " + url);
   return {


### PR DESCRIPTION
Hello,

Using HTTP urls results in an empty page, because the content cannot be loaded due to CSP violation.

> Why are you using HTTP urls ?

When using http://www.arxiv-sanity.com/ , the PDF link is in HTTP.

> Then arXiv-sanity should upgrade to put HTTPS links

That's what I thought. However, they are getting the URL straight from the arXiv API response, e.g. [this ling](https://export.arxiv.org/api/query?search_query=cat:cs.CV+OR+cat:cs.AI+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.NE+OR+cat:stat.ML&sortBy=lastUpdatedDate&start=0&max_results=2) gives an XML where we can see they refer to the link in HTTP :(

Also, the HTTP link doesn't result on malfunction on their end.