### PR TITLE
add arxiv HTML5(ar5iv) link for firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you are a researcher that reads a lot on ArXiv, you'll benefit a lot from thi
 - Renames the title of PDF page to the paper's title.
 - Adds a button to navigate back to Abstract page.
 - Download PDF with paper's title as filename.
+- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/) and [arXiv Vanity](https://www.arxiv-vanity.com/).
 - Works with Native Tab Search, and other plugins! (See the [Solution Descriptions](#solution-descriptions) section for more details)
 - All required permissions are documented in detail.
 
@@ -70,6 +71,7 @@ For ArXiv PDF / abstract tabs:
 - Renames the title to paper's title automatically in the background. (Originally is meaningless paper id, or start with paper id)
 - Add a browser button to open its corresponding abstract / PDF page. (Originally is hard to get back to abstract page from PDF page)
 - Add a direct download link on abstract page, click it to download the PDF with the title as filename. (Originally is paper id as filename)
+- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/) and [arXiv Vanity](https://www.arxiv-vanity.com/).
 - Better title even for bookmarks and the [OneTab](https://www.one-tab.com/) plugin!
 - Firefox has [strict restrictions on PDF.js](https://bugzilla.mozilla.org/show_bug.cgi?id=1454760). So it doesn't work well with OneTab, the PDF renaming is achieved by intercepting requests and show the PDF in a container. The bookmark works well though.
 - Works well with native tab search (credits: [@The Rooler](https://addons.mozilla.org/en-US/firefox/addon/arxiv-utils/reviews/1674567/))

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -48,8 +48,9 @@ async function getArticleInfoAsync(id, pageType) {
     publishedYear,
   }
 }
-// Add a direct download link in abstract page.
-async function addDownloadLinkAsync(id, articleInfo) {
+// Add a custom links in abstract page.
+async function addCustomLinksAsync(id, articleInfo) {
+  // Add direct download link.
   const result = await chrome.storage.sync.get({
     'filename_format': '${title}, ${firstAuthor} et al., ${publishedYear}.pdf'
   });
@@ -59,16 +60,37 @@ async function addDownloadLinkAsync(id, articleInfo) {
     .replace('${firstAuthor}', articleInfo.firstAuthor)
     .replace('${publishedYear}', articleInfo.publishedYear);
   const directURL = `https://arxiv.org/pdf/${id}.pdf`;
-  const elementId = "arxiv-utils-direct-download-li";
-  document.getElementById(elementId)?.remove();
-  const htmlInsert = `<li id="${elementId}"><a href="${directURL}" download="${fileName}" type="application/pdf">Direct Download</a></li>`;
-  const elUL = document.querySelector(".full-text > ul");
-  if (!elUL) {
+  const directDownloadId = "arxiv-utils-direct-download-li";
+  document.getElementById(directDownloadId)?.remove();
+  const directDownloadHTML = ` \
+    <li id="${directDownloadId}"> \
+      <a href="${directURL}" download="${fileName}" type="application/pdf">Direct Download</a> \
+    </li>`;
+  const downloadUL = document.querySelector(".full-text > ul");
+  if (!downloadUL) {
     console.error(LOG_PREFIX, "Error: Cannot find the unordered list inside the Download section at the right side of the abstract page.");
     return;
   }
-  elUL.innerHTML += htmlInsert;
+  downloadUL.innerHTML += directDownloadHTML;
   console.log(LOG_PREFIX, "Added direct download link.")
+  // Add extra services links.
+  const elExtraRefCite = document.querySelector(".extra-ref-cite");
+  if (!elExtraRefCite) {
+    console.error(LOG_PREFIX, "Error: Cannot find the References & Citations section at the right side of the abstract page.");
+    return;
+  }
+  const extraServicesId = "arxiv-utils-extra-services-div";
+  document.getElementById(extraServicesId)?.remove();
+  const extraServicesDiv = document.createElement("div");
+  extraServicesDiv.classList.add('extra-ref-cite');
+  extraServicesDiv.id = extraServicesId;
+  extraServicesDiv.innerHTML = ` \
+    <h3>Extra Services</h3> \
+    <ul> \
+      <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
+      <li><a href="https://www.arxiv-vanity.com/papers/${id}">arXiv Vanity</a></li> \
+    </ul>`;
+  elExtraRefCite.after(extraServicesDiv);
 }
 
 // The PDF viewer in Chrome has a bug that will overwrite the title of the page after loading the PDF.
@@ -109,7 +131,7 @@ async function mainAsync() {
   document.title = articleInfo.newTitle;
   console.log(LOG_PREFIX, `Set document title to: ${articleInfo.newTitle}.`);
   if (pageType === "Abstract")
-    addDownloadLinkAsync(id, articleInfo);
+    addCustomLinksAsync(id, articleInfo);
   // Store new title for onMessage.
   newTitle = articleInfo.newTitle
 }


### PR DESCRIPTION
Hello, I find it often useful to view arxiv papers in HTML5 instead of PDF. The official instruction is to replace any arXiv article URL by changing the X to a 5.
This PR simply adds the link of HTML5 version next to 'Direct Download' link on the abstract page.
Really hope you can merge it.