### PR TITLE
Add keyboard shortcut

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -19,6 +19,13 @@
     },
     "default_title": "Open Abstract / PDF"
   },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+A"
+      }
+    }
+  },
   "permissions": [
     "tabs",
     "activeTab",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -19,6 +19,13 @@
     },
     "default_title": "Open Abstract / PDF"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+A"
+      }
+    }
+  },
   "permissions": [
     "tabs",
     "activeTab",


### PR DESCRIPTION
Here is the keyboard shortcut feature mentioned in https://github.com/j3soon/arxiv-utils/issues/24.

Note: I tested on Edge and Firefox, maybe Chrome work as well.