### PR TITLE
Add link for RSS feed for paper

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -113,6 +113,7 @@ async function addCustomLinksAsync(id, articleInfo) {
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
       <li><a href="https://www.arxiv-vanity.com/papers/${id}">arXiv Vanity</a></li> \
+      <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;
   elExtraRefCite.after(extraServicesDiv);
 }

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -114,6 +114,7 @@ async function addCustomLinksAsync(id, articleInfo) {
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
       <li><a href="https://www.arxiv-vanity.com/papers/${id}">arXiv Vanity</a></li> \
+      <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;
   elExtraRefCite.after(extraServicesDiv);
 }


### PR DESCRIPTION
This pull request adds a link to the RSS feed of a paper in the Extra Services section.
While it is not a foolproof method, a RSS feed is valuable for monitoring the status of a preprint, whether it has been accepted for publication, published, or retracted.