### PR TITLE
feat: add papers.cool entry and navigation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A collection of features that enhance your reading experience on ArXiv (and some
 - Renames the title of PDF page to the paper's title.
 - Adds a button and hotkey (`Alt+A`) to navigate back to Abstract page for arXiv, OpenReview, and more.
 - Download PDF with paper's title as filename.
-- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/).
+- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/) and [papers.cool](https://papers.cool/).
 - Works with Native Tab Search, and other plugins! (See the [Solution Descriptions](#solution-descriptions) section for more details)
 - All required permissions are documented in detail.
 
@@ -43,7 +43,7 @@ Alternatively, these 3 browsers can also load arxiv-utils directly from source. 
 
 The paper id in the title has been removed automatically!  
 A direct download link is added to download PDF with paper's title as the filename!  
-Open in extra services such as ar5iv!
+Open in extra services such as ar5iv and papers.cool!
 ![](screenshots/01-abstract.png)
 Finally... Meaningful paper title instead of paper id! (For Firefox, this is achieved through a custom PDF container.)
 ![](screenshots/02-pdf.png)
@@ -73,7 +73,7 @@ For ArXiv PDF / abstract tabs:
 - Renames the title to paper's title automatically in the background. (Originally is meaningless paper id, or start with paper id)
 - Add an action button (or `Alt+A`) to open its corresponding abstract / PDF page. (Originally is hard to get back to abstract page from PDF page)
 - Add a direct download link on abstract page, click it to download the PDF with the title as filename. (Originally is paper id as filename)
-- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/).
+- Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/) and [papers.cool](https://papers.cool/).
 - Better title even for bookmarks and the [OneTab](https://www.one-tab.com/) plugin!
 - Firefox has [strict restrictions on PDF.js](https://bugzilla.mozilla.org/show_bug.cgi?id=1454760). So it doesn't work well with OneTab, the PDF renaming is achieved by intercepting requests and show the PDF in a container. The bookmark works well though.
 - Works well with native tab search (credits: [@The Rooler](https://addons.mozilla.org/en-US/firefox/addon/arxiv-utils/reviews/1674567/))

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -10,6 +10,7 @@ var ID_REGEXP_REPLACE = [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "$1$2", "PDF"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "$1", "HTML5"],
   [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "$1", "papers.cool"],
+  [/^.*:\/\/papers\.cool\/arxiv\/([^\/\?\#]+)\/*(\?.*?)?(\#.*?)?$/, "$1", "papers.cool"],
 ];
 // Store new title for onMessage to deal with Chrome PDF viewer bug.
 var newTitle = undefined;
@@ -131,7 +132,7 @@ function addCustomLinksAsync(id) {
     <h3>Extra Services</h3> \
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
-      <li><a href="https://papers.cool/arxiv/search?highlight=1&query=${id}">papers.cool</a></li> \
+      <li><a href="https://papers.cool/arxiv/${id}">papers.cool</a></li> \
       <li><a href="https://alphaxiv.org/abs/${id}">alphaXiv</a></li> \
       <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -9,6 +9,7 @@ var ID_REGEXP_REPLACE = [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/pdf\/(\S*?)(?:\.pdf)?\/*(\?.*?)?(\#.*?)?$/, "$1", "PDF"],
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "$1$2", "PDF"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "$1", "HTML5"],
+  [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "$1", "papers.cool"],
 ];
 // Store new title for onMessage to deal with Chrome PDF viewer bug.
 var newTitle = undefined;
@@ -130,6 +131,7 @@ function addCustomLinksAsync(id) {
     <h3>Extra Services</h3> \
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
+      <li><a href="https://papers.cool/arxiv/search?highlight=1&query=${id}">papers.cool</a></li> \
       <li><a href="https://alphaxiv.org/abs/${id}">alphaXiv</a></li> \
       <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,12 +12,13 @@
       "*://arxiv.org/abs/*",
       "*://export.arxiv.org/*pdf*",
       "*://export.arxiv.org/abs/*",
-      "*://browse.arxiv.org/*pdf*",
-      "*://browse.arxiv.org/abs/*",
-      "*://www.arxiv.org/*pdf*",
-      "*://www.arxiv.org/abs/*",
-      "*://ar5iv.labs.arxiv.org/html/*"
-    ],
+        "*://browse.arxiv.org/*pdf*",
+        "*://browse.arxiv.org/abs/*",
+        "*://www.arxiv.org/*pdf*",
+        "*://www.arxiv.org/abs/*",
+        "*://ar5iv.labs.arxiv.org/html/*",
+        "*://papers.cool/arxiv/search*"
+      ],
     "js": [ "content.js" ],
     "run_at": "document_end"
   }],
@@ -48,7 +49,8 @@
     "*://export.arxiv.org/*",
     "*://browse.arxiv.org/*",
     "*://www.arxiv.org/*",
-    "*://ar5iv.labs.arxiv.org/*"
+    "*://ar5iv.labs.arxiv.org/*",
+    "*://papers.cool/*"
   ],
   "icons": {
     "16": "icon16.png",

--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -12,6 +12,7 @@ export default [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1$2"],
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],

--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -13,6 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/papers\.cool\/arxiv\/([^\/\?\#]+)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -10,6 +10,7 @@ const ID_REGEXP_REPLACE = [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "$1$2", "PDF"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "$1", "HTML5"],
   [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "$1", "papers.cool"],
+  [/^.*:\/\/papers\.cool\/arxiv\/([^\/\?\#]+)\/*(\?.*?)?(\#.*?)?$/, "$1", "papers.cool"],
   // For external PDF viewer
   [/^.*:\/\/mozilla\.github\.io\/pdf\.js\/web\/viewer\.html\?file=https:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/pdf\/(\S*?)(?:\.pdf)?\/*(?:#zoom=.*)?$/, "$1"],
 ];
@@ -121,7 +122,7 @@ function addCustomLinksAsync(id) {
     <h3>Extra Services</h3> \
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
-      <li><a href="https://papers.cool/arxiv/search?highlight=1&query=${id}">papers.cool</a></li> \
+      <li><a href="https://papers.cool/arxiv/${id}">papers.cool</a></li> \
       <li><a href="https://alphaxiv.org/abs/${id}">alphaXiv</a></li> \
       <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -9,6 +9,7 @@ const ID_REGEXP_REPLACE = [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/pdf\/(\S*?)(?:\.pdf)?\/*(\?.*?)?(\#.*?)?$/, "$1", "PDF"],
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "$1$2", "PDF"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "$1", "HTML5"],
+  [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "$1", "papers.cool"],
   // For external PDF viewer
   [/^.*:\/\/mozilla\.github\.io\/pdf\.js\/web\/viewer\.html\?file=https:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/pdf\/(\S*?)(?:\.pdf)?\/*(?:#zoom=.*)?$/, "$1"],
 ];
@@ -120,6 +121,7 @@ function addCustomLinksAsync(id) {
     <h3>Extra Services</h3> \
     <ul> \
       <li><a href="https://ar5iv.labs.arxiv.org/html/${id}">ar5iv (HTML 5)</a></li> \
+      <li><a href="https://papers.cool/arxiv/search?highlight=1&query=${id}">papers.cool</a></li> \
       <li><a href="https://alphaxiv.org/abs/${id}">alphaXiv</a></li> \
       <li><a href="https://export.arxiv.org/api/query/id_list/${id}">RSS feed</a></li> \
     </ul>`;

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -12,6 +12,7 @@
       "*://browse.arxiv.org/abs/*",
       "*://www.arxiv.org/abs/*",
       "*://ar5iv.labs.arxiv.org/html/*",
+      "*://papers.cool/arxiv/search*",
       "*://mozilla.github.io/pdf.js/web/viewer.html*"
     ],
     "js": [ "content.js" ],

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -12,6 +12,7 @@ export default [
   [/^.*:\/\/(?:export\.|browse\.|www\.)?arxiv\.org\/ftp\/(?:arxiv\/|([^\/]*\/))papers\/.*?([^\/]*?)\.pdf(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1$2"],
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -13,6 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/papers\.cool\/arxiv\/search\?(?:.*?&)?query=(\S*?)(&.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/papers\.cool\/arxiv\/([^\/\?\#]+)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -177,6 +177,11 @@ navigation:
   url2: https://arxiv.org/abs/1512.03385
   title2: Deep Residual Learning for Image Recognition | Abstract
   description: ar5iv -> arXiv
+- url: https://papers.cool/arxiv/search?highlight=1&query=1512.03385
+  title: "Search papers with code highlights by query: 1512.03385"
+  url2: https://arxiv.org/abs/1512.03385
+  title2: Deep Residual Learning for Image Recognition | Abstract
+  description: papers.cool -> arXiv
 - url: https://huggingface.co/papers/2408.00714
   title: "Paper page - SAM 2: Segment Anything in Images and Videos"
   url2: https://arxiv.org/abs/2408.00714

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -177,8 +177,8 @@ navigation:
   url2: https://arxiv.org/abs/1512.03385
   title2: Deep Residual Learning for Image Recognition | Abstract
   description: ar5iv -> arXiv
-- url: https://papers.cool/arxiv/search?highlight=1&query=1512.03385
-  title: "Search papers with code highlights by query: 1512.03385"
+- url: https://papers.cool/arxiv/1512.03385
+  title: Deep Residual Learning for Image Recognition
   url2: https://arxiv.org/abs/1512.03385
   title2: Deep Residual Learning for Image Recognition | Abstract
   description: papers.cool -> arXiv


### PR DESCRIPTION
## Summary
- Add a new **papers.cool** entry under **Extra Services** on arXiv abstract pages.
- papers.cool link format: `https://papers.cool/arxiv/search?highlight=1&query=<arxiv_id>`.
- Add papers.cool URL parsing/mapping so the extension button can navigate from papers.cool pages back to the corresponding arXiv abstract page, analogous to existing ar5iv support.
- Update Chrome/Firefox manifests for papers.cool URL matching and host access.
- Update README references from "ar5iv" to "ar5iv + papers.cool" where appropriate.
- Add navigation testcase for `papers.cool -> arXiv`.

## What is papers.cool and why this helps
[papers.cool](https://papers.cool/) is a paper discovery/search site. In this integration, arxiv-utils can open papers.cool directly from arXiv via:
`https://papers.cool/arxiv/search?highlight=1&query=<arxiv_id>`
This keeps user flow smooth when browsing related code-oriented search results and still allows quick navigation back to canonical arXiv pages with the extension button/hotkey.

## Validation
- Unit navigation test passed locally (`tests/unit-test`, `npm test -- --runInBand`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for papers.cool as an additional external service to access arXiv papers
  * Extension now recognizes and properly handles papers.cool domain URLs
  * Papers can be seamlessly accessed through papers.cool alongside existing services

* **Tests**
  * Added test cases to verify papers.cool functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j3soon/arxiv-utils/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->