### PR TITLE
Support navigation from alphaXiv to arXiv abstract

### DIFF
--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -13,6 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/abs\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],
   // Starting from 2022, NIPS urls may end with a `-Conference` suffix

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -13,6 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/abs\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],
   // Starting from 2022, NIPS urls may end with a `-Conference` suffix

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -182,6 +182,9 @@ navigation:
   url2: https://arxiv.org/abs/2408.00714
   title2: "SAM 2: Segment Anything in Images and Videos | Abstract"
   description: ar5iv -> arXiv
+- url: https://www.alphaxiv.org/abs/1706.03762
+  url2: https://arxiv.org/abs/1706.03762
+  description: alphaXiv -> arXiv
 - url: https://openreview.net/pdf?id=LcF-EEt8cCC
   url2: https://openreview.net/forum?id=LcF-EEt8cCC
   title2: Denoising Likelihood Score Matching for Conditional Score-based Data Generation | OpenReview


### PR DESCRIPTION
## Summary

Clicking the extension icon on an arXiv abstract page jumps to the PDF, and clicking again on the PDF goes back to the abstract. A natural extension of this behavior is to also return to the arXiv abstract from an alphaXiv page. This PR implements that.

For example, clicking the icon on `https://www.alphaxiv.org/abs/1706.03762?chatId=...` now navigates to `https://arxiv.org/abs/1706.03762`.

## Changes

- Added an alphaXiv → arXiv abstract rule to `target_url_regexp_replace.js` (both Chrome and Firefox)
- Added a testcase using 1706.03762 to `tests/testcases/testcases.yaml`

## Test plan

- [x] `npm test` passes (68/68 navigation testcases)
- [x] Manually verified on `https://www.alphaxiv.org/abs/<id>` that clicking the extension icon navigates to `https://arxiv.org/abs/<id>` in chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic URL redirection functionality that seamlessly converts alphaxiv.org abstract page links to their corresponding arxiv.org equivalents, significantly improving user accessibility when accessing research papers from different sources.

* **Tests**
  * Added test case verifying correct URL redirection behavior from alphaxiv.org/abs to arxiv.org/abs pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j3soon/arxiv-utils/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->