### PR TITLE
Feat/usenix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 A collection of features that enhance your reading experience on ArXiv (and some other sites):
 
 - Renames the title of PDF page to the paper's title.
-- Adds a button and hotkey (`Alt+A`) to navigate back to Abstract page for arXiv, OpenReview, and more.
+- Adds a button and hotkey (`Alt+A`) to navigate back to Abstract page for arXiv, OpenReview, USENIX, and more.
 - Download PDF with paper's title as filename.
 - Open the paper in extra services such as [ar5iv](https://ar5iv.labs.arxiv.org/).
 - Works with Native Tab Search, and other plugins! (See the [Solution Descriptions](#solution-descriptions) section for more details)

--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -31,4 +31,25 @@ export default [
   [/^.*:\/\/ieeexplore\.ieee\.org\/stamp\/stamp\.jsp\?(?:.*?&)?arnumber=(\d+)(&.*?)?(\#.*?)?$/, "https://ieeexplore.ieee.org/document/$1"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\.pdf(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1/"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\/(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1.pdf"],
+  // USENIX legacy technical-sessions format (subdir PDFs, ~2012-2018), listed before the
+  // flat format so these more specific patterns match first.
+  // presentation -> PDF is calibrated to the NSDI-style `-paper-` infix (e.g. nsdi14).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/technical-sessions\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/conference/$1/$1-paper-$2.pdf"],
+  // PDF -> presentation: the conference code comes from the subdir, so a differing file
+  // prefix (e.g. `sec<NN>` for USENIX Security) is irrelevant; tolerate an optional
+  // paper-/papers- infix.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/conference\/([^\/]+)\/[^\/]+?-(?:papers?-)?([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/$1/technical-sessions/presentation/$2"],
+  // USENIX Security flat PDFs use a `sec<NN>` prefix (~2019-2022) while the conference path
+  // code is `usenixsecurity<NN>`. Map it explicitly; must precede the generic flat rule.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/sec(\d+)-([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/usenixsecurity$1/presentation/$2"],
+  // USENIX flat format (~2018+, e.g. nsdi26, fast26, usenixsecurity24):
+  // `/conference/<conf>/presentation/<slug>` <-> `/system/files/<conf>-<slug>.pdf`.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/$1-$2.pdf"],
+  // PDF -> presentation: tolerate an optional `paper-` infix some flat files carry (e.g. nsdi20).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/([^\/]+?)-(?:paper-)?([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/$1/presentation/$2"],
 ];

--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -31,6 +31,11 @@ export default [
   [/^.*:\/\/ieeexplore\.ieee\.org\/stamp\/stamp\.jsp\?(?:.*?&)?arnumber=(\d+)(&.*?)?(\#.*?)?$/, "https://ieeexplore.ieee.org/document/$1"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\.pdf(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1/"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\/(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1.pdf"],
+  // USENIX Security legacy technical-sessions PDFs use a `sec<NN>` file prefix, not the
+  // `usenixsecurity<NN>` path code; rewrite to that prefix. Must precede the generic legacy
+  // rule below (first-match-wins) so Security pages do not get the wrong prefix.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/usenixsecurity(\d+)\/technical-sessions\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/conference/usenixsecurity$1/sec$1-$2.pdf"],
   // USENIX legacy technical-sessions format (subdir PDFs, ~2012-2018), listed before the
   // flat format so these more specific patterns match first.
   // presentation -> PDF is calibrated to the NSDI-style `-paper-` infix (e.g. nsdi14).
@@ -45,6 +50,11 @@ export default [
   // code is `usenixsecurity<NN>`. Map it explicitly; must precede the generic flat rule.
   [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/sec(\d+)-([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
     "https://www.usenix.org/conference/usenixsecurity$1/presentation/$2"],
+  // USENIX Security flat PDFs used the `sec<NN>` prefix through 2022 before switching to
+  // `usenixsecurity<NN>` in 2023; rewrite those years explicitly. Must precede the generic
+  // flat rule below. 2023+ falls through to it (path code already matches the file prefix).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/usenixsecurity(19|20|21|22)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/sec$1-$2.pdf"],
   // USENIX flat format (~2018+, e.g. nsdi26, fast26, usenixsecurity24):
   // `/conference/<conf>/presentation/<slug>` <-> `/system/files/<conf>-<slug>.pdf`.
   [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -31,4 +31,25 @@ export default [
   [/^.*:\/\/ieeexplore\.ieee\.org\/stamp\/stamp\.jsp\?(?:.*?&)?arnumber=(\d+)(&.*?)?(\#.*?)?$/, "https://ieeexplore.ieee.org/document/$1"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\.pdf(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1/"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\/(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1.pdf"],
+  // USENIX legacy technical-sessions format (subdir PDFs, ~2012-2018), listed before the
+  // flat format so these more specific patterns match first.
+  // presentation -> PDF is calibrated to the NSDI-style `-paper-` infix (e.g. nsdi14).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/technical-sessions\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/conference/$1/$1-paper-$2.pdf"],
+  // PDF -> presentation: the conference code comes from the subdir, so a differing file
+  // prefix (e.g. `sec<NN>` for USENIX Security) is irrelevant; tolerate an optional
+  // paper-/papers- infix.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/conference\/([^\/]+)\/[^\/]+?-(?:papers?-)?([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/$1/technical-sessions/presentation/$2"],
+  // USENIX Security flat PDFs use a `sec<NN>` prefix (~2019-2022) while the conference path
+  // code is `usenixsecurity<NN>`. Map it explicitly; must precede the generic flat rule.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/sec(\d+)-([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/usenixsecurity$1/presentation/$2"],
+  // USENIX flat format (~2018+, e.g. nsdi26, fast26, usenixsecurity24):
+  // `/conference/<conf>/presentation/<slug>` <-> `/system/files/<conf>-<slug>.pdf`.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/$1-$2.pdf"],
+  // PDF -> presentation: tolerate an optional `paper-` infix some flat files carry (e.g. nsdi20).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/([^\/]+?)-(?:paper-)?([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/conference/$1/presentation/$2"],
 ];

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -31,6 +31,11 @@ export default [
   [/^.*:\/\/ieeexplore\.ieee\.org\/stamp\/stamp\.jsp\?(?:.*?&)?arnumber=(\d+)(&.*?)?(\#.*?)?$/, "https://ieeexplore.ieee.org/document/$1"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\.pdf(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1/"],
   [/^.*:\/\/aclanthology\.org\/([^\/]+)\/(\?.*?)?(\#.*?)?$/, "https://aclanthology.org/$1.pdf"],
+  // USENIX Security legacy technical-sessions PDFs use a `sec<NN>` file prefix, not the
+  // `usenixsecurity<NN>` path code; rewrite to that prefix. Must precede the generic legacy
+  // rule below (first-match-wins) so Security pages do not get the wrong prefix.
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/usenixsecurity(\d+)\/technical-sessions\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/conference/usenixsecurity$1/sec$1-$2.pdf"],
   // USENIX legacy technical-sessions format (subdir PDFs, ~2012-2018), listed before the
   // flat format so these more specific patterns match first.
   // presentation -> PDF is calibrated to the NSDI-style `-paper-` infix (e.g. nsdi14).
@@ -45,6 +50,11 @@ export default [
   // code is `usenixsecurity<NN>`. Map it explicitly; must precede the generic flat rule.
   [/^.*:\/\/(?:www\.)?usenix\.org\/system\/files\/sec(\d+)-([^\/]+?)\.pdf(?:\?.*?)?(?:\#.*?)?$/,
     "https://www.usenix.org/conference/usenixsecurity$1/presentation/$2"],
+  // USENIX Security flat PDFs used the `sec<NN>` prefix through 2022 before switching to
+  // `usenixsecurity<NN>` in 2023; rewrite those years explicitly. Must precede the generic
+  // flat rule below. 2023+ falls through to it (path code already matches the file prefix).
+  [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/usenixsecurity(19|20|21|22)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,
+    "https://www.usenix.org/system/files/sec$1-$2.pdf"],
   // USENIX flat format (~2018+, e.g. nsdi26, fast26, usenixsecurity24):
   // `/conference/<conf>/presentation/<slug>` <-> `/system/files/<conf>-<slug>.pdf`.
   [/^.*:\/\/(?:www\.)?usenix\.org\/conference\/([^\/]+)\/presentation\/([^\/?#]+)\/*(?:\?.*?)?(?:\#.*?)?$/,

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -446,11 +446,18 @@ navigation:
 - url: https://www.usenix.org/system/files/conference/fast16/fast16-papers-andersen.pdf
   url2: https://www.usenix.org/conference/fast16/technical-sessions/presentation/andersen
   description: USENIX FAST'16 legacy pdf (papers- infix) -> presentation
-# USENIX Security flat files use a `sec<NN>` prefix mapped back to `usenixsecurity<NN>`:
+# USENIX Security flat files use a `sec<NN>` prefix (2019-2022) mapped to/from the
+# `usenixsecurity<NN>` path code (both directions):
+- url: https://www.usenix.org/conference/usenixsecurity20/presentation/afek
+  url2: https://www.usenix.org/system/files/sec20-afek.pdf
+  description: USENIX Security'20 presentation -> flat pdf (sec prefix)
 - url: https://www.usenix.org/system/files/sec20-afek.pdf
   url2: https://www.usenix.org/conference/usenixsecurity20/presentation/afek
   description: USENIX Security'20 flat pdf (sec prefix) -> presentation
-# USENIX Security legacy subdir: conference code recovered from the subdir, not the sec prefix:
+# USENIX Security legacy subdir uses the `sec<NN>` prefix too (both directions):
+- url: https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/alexopoulos
+  url2: https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-alexopoulos.pdf
+  description: USENIX Security'17 legacy presentation -> pdf (sec prefix in subdir)
 - url: https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-alexopoulos.pdf
   url2: https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/alexopoulos
   description: USENIX Security'17 legacy pdf (sec prefix in subdir) -> presentation

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -351,6 +351,109 @@ navigation:
   title: Why are Sensitive Functions Hard for Transformers? - ACL Anthology
   url2: https://aclanthology.org/2024.acl-long.800.pdf
   description: ACL abs -> pdf
+# USENIX (modern flat format, ~2019+)
+- url: https://www.usenix.org/conference/nsdi26/presentation/chen-jiayi
+  title: "UNUM: A New Framework for Network Control | USENIX"
+  url2: https://www.usenix.org/system/files/nsdi26-chen-jiayi.pdf
+  description: USENIX modern presentation -> pdf
+- url: https://www.usenix.org/system/files/nsdi26-chen-jiayi.pdf
+  url2: https://www.usenix.org/conference/nsdi26/presentation/chen-jiayi
+  title2: "UNUM: A New Framework for Network Control | USENIX"
+  description: USENIX modern pdf -> presentation
+- url: https://www.usenix.org/conference/fast26/presentation/wang
+  title: "Cost-efficient Archive Cloud Storage with Tape: Design and Deployment | USENIX"
+  url2: https://www.usenix.org/system/files/fast26-wang.pdf
+  description: USENIX modern presentation -> pdf (single-token slug)
+- url: https://www.usenix.org/system/files/fast26-wang.pdf
+  url2: https://www.usenix.org/conference/fast26/presentation/wang
+  title2: "Cost-efficient Archive Cloud Storage with Tape: Design and Deployment | USENIX"
+  description: USENIX modern pdf -> presentation (single-token slug)
+- url: https://www.usenix.org/conference/nsdi23/presentation/wang-zilong
+  title: "SRNIC: A Scalable Architecture for RDMA NICs | USENIX"
+  url2: https://www.usenix.org/system/files/nsdi23-wang-zilong.pdf
+  description: USENIX modern presentation -> pdf (hyphenated slug)
+- url: https://www.usenix.org/system/files/nsdi23-wang-zilong.pdf
+  url2: https://www.usenix.org/conference/nsdi23/presentation/wang-zilong
+  title2: "SRNIC: A Scalable Architecture for RDMA NICs | USENIX"
+  description: USENIX modern pdf -> presentation (hyphenated slug)
+# USENIX (legacy technical-sessions format, e.g. nsdi14)
+- url: https://www.usenix.org/conference/nsdi14/technical-sessions/presentation/liu_he
+  title: Circuit Switching Under the Radar with REACToR | USENIX
+  url2: https://www.usenix.org/system/files/conference/nsdi14/nsdi14-paper-liu_he.pdf
+  description: USENIX legacy presentation -> pdf
+- url: https://www.usenix.org/system/files/conference/nsdi14/nsdi14-paper-liu_he.pdf
+  url2: https://www.usenix.org/conference/nsdi14/technical-sessions/presentation/liu_he
+  title2: Circuit Switching Under the Radar with REACToR | USENIX
+  description: USENIX legacy pdf -> presentation
+# USENIX modern format generalizes across conference families (the `<conf>` code is
+# captured generically): USENIX Security (`usenixsecurity<NN>`, no longer the old
+# `sec<NN>` prefix), 4-digit-year SOUPS, and co-located workshops such as WOOT.
+- url: https://www.usenix.org/conference/usenixsecurity25/presentation/gibson
+  title: Analyzing the AI Nudification Application Ecosystem | USENIX
+  url2: https://www.usenix.org/system/files/usenixsecurity25-gibson.pdf
+  description: USENIX Security presentation -> pdf
+- url: https://www.usenix.org/system/files/usenixsecurity25-gibson.pdf
+  url2: https://www.usenix.org/conference/usenixsecurity25/presentation/gibson
+  title2: Analyzing the AI Nudification Application Ecosystem | USENIX
+  description: USENIX Security pdf -> presentation
+- url: https://www.usenix.org/conference/soups2025/presentation/oak-butchering
+  url2: https://www.usenix.org/system/files/soups2025-oak-butchering.pdf
+  description: USENIX SOUPS (4-digit year) presentation -> pdf
+- url: https://www.usenix.org/system/files/soups2025-oak-butchering.pdf
+  url2: https://www.usenix.org/conference/soups2025/presentation/oak-butchering
+  description: USENIX SOUPS (4-digit year) pdf -> presentation
+- url: https://www.usenix.org/conference/woot25/presentation/muench
+  title: "Security through Transparency: Tales from the RP2350 Hacking Challenge | USENIX"
+  url2: https://www.usenix.org/system/files/woot25-muench.pdf
+  description: USENIX WOOT workshop presentation -> pdf
+- url: https://www.usenix.org/system/files/woot25-muench.pdf
+  url2: https://www.usenix.org/conference/woot25/presentation/muench
+  title2: "Security through Transparency: Tales from the RP2350 Hacking Challenge | USENIX"
+  description: USENIX WOOT workshop pdf -> presentation
+# USENIX coverage across conference families / years (verified against live URLs).
+# Legacy technical-sessions format with the NSDI-style `-paper-` infix (both directions):
+- url: https://www.usenix.org/conference/osdi14/technical-sessions/presentation/angel
+  url2: https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-angel.pdf
+  description: USENIX OSDI'14 legacy presentation -> pdf
+- url: https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-angel.pdf
+  url2: https://www.usenix.org/conference/osdi14/technical-sessions/presentation/angel
+  description: USENIX OSDI'14 legacy pdf -> presentation
+# Flat format across families/years (both directions):
+- url: https://www.usenix.org/conference/osdi18/presentation/alagappan
+  url2: https://www.usenix.org/system/files/osdi18-alagappan.pdf
+  description: USENIX OSDI'18 flat presentation -> pdf
+- url: https://www.usenix.org/system/files/osdi18-alagappan.pdf
+  url2: https://www.usenix.org/conference/osdi18/presentation/alagappan
+  description: USENIX OSDI'18 flat pdf -> presentation
+- url: https://www.usenix.org/conference/fast22/presentation/an
+  url2: https://www.usenix.org/system/files/fast22-an.pdf
+  description: USENIX FAST'22 flat presentation -> pdf
+- url: https://www.usenix.org/system/files/fast22-an.pdf
+  url2: https://www.usenix.org/conference/fast22/presentation/an
+  description: USENIX FAST'22 flat pdf -> presentation
+- url: https://www.usenix.org/conference/atc23/presentation/al-fares
+  url2: https://www.usenix.org/system/files/atc23-al-fares.pdf
+  description: USENIX ATC'23 flat presentation -> pdf (hyphenated slug)
+- url: https://www.usenix.org/system/files/atc23-al-fares.pdf
+  url2: https://www.usenix.org/conference/atc23/presentation/al-fares
+  description: USENIX ATC'23 flat pdf -> presentation (hyphenated slug)
+# Reverse-only wins: the forward (presentation -> pdf) filename is not derivable for these,
+# but pdf -> presentation is. A flat file with a stray `-paper-` infix (NSDI'20):
+- url: https://www.usenix.org/system/files/nsdi20-paper-abhashkumar.pdf
+  url2: https://www.usenix.org/conference/nsdi20/presentation/abhashkumar
+  description: USENIX NSDI'20 flat pdf (paper- infix) -> presentation
+# A legacy file with a `papers-` (plural) infix (FAST'16):
+- url: https://www.usenix.org/system/files/conference/fast16/fast16-papers-andersen.pdf
+  url2: https://www.usenix.org/conference/fast16/technical-sessions/presentation/andersen
+  description: USENIX FAST'16 legacy pdf (papers- infix) -> presentation
+# USENIX Security flat files use a `sec<NN>` prefix mapped back to `usenixsecurity<NN>`:
+- url: https://www.usenix.org/system/files/sec20-afek.pdf
+  url2: https://www.usenix.org/conference/usenixsecurity20/presentation/afek
+  description: USENIX Security'20 flat pdf (sec prefix) -> presentation
+# USENIX Security legacy subdir: conference code recovered from the subdir, not the sec prefix:
+- url: https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-alexopoulos.pdf
+  url2: https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/alexopoulos
+  description: USENIX Security'17 legacy pdf (sec prefix in subdir) -> presentation
 
 # TODO: Test download filenames:
 #       - Title with colon: https://arxiv.org/abs/2102.07936


### PR DESCRIPTION
## What

Adds USENIX conference papers support, matching the support already provided for arXiv, OpenReview, NIPS, PMLR, CVF, JMLR, IEEE, and ACL. 

Navigates e.g. between:
- `https://www.usenix.org/conference/nsdi26/presentation/chen-jiayi`
- `https://www.usenix.org/system/files/nsdi26-chen-jiayi.pdf`

## Scope

USENIX URLs have two structural generations plus a long tail of per-paper irregularities. LLM agents and me surveyed a representative paper from every NSDI/OSDI/ATC/FAST/USENIX Security edition 2012–2026, and added every transformation derivable from the URL. Measured coverage: presentation -> PDF 34/64, PDF -> presentation 47/64.

Not URL-derivable, hence unsupported (best-effort, like the other site mappings): pre-2014 submission-number filenames, per-paper slug truncation/underscore/`_N` suffixes, and the 2018 flat-path/subdir-PDF transition.

## Tests

Added navigation testcases spanning the format/era matrix to `tests/testcases/testcases.yaml`, all verified against live URLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded support for USENIX conference links by recognizing and normalizing additional legacy and modern presentation/PDF URL formats.
  * Improved back-navigation/help text to include USENIX alongside arXiv and OpenReview.

* **Tests**
  * Added extensive Jest-only test cases covering multiple USENIX URL patterns, including legacy technical-session structures and `sec<NN>` Security variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->