### PR TITLE
feat: Support navigation from alphaXiv overview/replicate/audio pages

### DIFF
--- a/chrome/target_url_regexp_replace.js
+++ b/chrome/target_url_regexp_replace.js
@@ -13,7 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
-  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/abs\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/(?:abs|overview|replicate|audio)\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],
   // Starting from 2022, NIPS urls may end with a `-Conference` suffix

--- a/firefox/target_url_regexp_replace.js
+++ b/firefox/target_url_regexp_replace.js
@@ -13,7 +13,7 @@ export default [
   [/^.*:\/\/(?:browse\.|www\.)?arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/ar5iv\.labs\.arxiv\.org\/html\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/huggingface\.co\/papers\/(\S*?)(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
-  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/abs\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
+  [/^.*:\/\/(?:www\.)?alphaxiv\.org\/(?:abs|overview|replicate|audio)\/(\S*?)\/*(\?.*?)?(\#.*?)?$/, "https://arxiv.org/abs/$1"],
   [/^.*:\/\/openreview\.net\/forum\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/pdf?id=$1"],
   [/^.*:\/\/openreview\.net\/pdf\?(?:.*?&)?id=(\S*?)(&.*?)?(\#.*?)?$/, "https://openreview.net/forum?id=$1"],
   // Starting from 2022, NIPS urls may end with a `-Conference` suffix

--- a/tests/testcases/testcases.yaml
+++ b/tests/testcases/testcases.yaml
@@ -185,6 +185,15 @@ navigation:
 - url: https://www.alphaxiv.org/abs/1706.03762
   url2: https://arxiv.org/abs/1706.03762
   description: alphaXiv -> arXiv
+- url: https://www.alphaxiv.org/overview/1706.03762
+  url2: https://arxiv.org/abs/1706.03762
+  description: alphaXiv overview -> arXiv
+- url: https://www.alphaxiv.org/replicate/1706.03762
+  url2: https://arxiv.org/abs/1706.03762
+  description: alphaXiv replicate -> arXiv
+- url: https://www.alphaxiv.org/audio/1706.03762
+  url2: https://arxiv.org/abs/1706.03762
+  description: alphaXiv audio -> arXiv
 - url: https://openreview.net/pdf?id=LcF-EEt8cCC
   url2: https://openreview.net/forum?id=LcF-EEt8cCC
   title2: Denoising Likelihood Score Matching for Conditional Score-based Data Generation | OpenReview


### PR DESCRIPTION
Hi @j3soon , sorry to bother you again. A while ago, I made a PR (https://github.com/j3soon/arxiv-utils/pull/67) that jumps from alphaxiv to arxiv by this extension. I noticed that the alphaxiv URL can take different forms, that is `https://www.alphaxiv.org/{abs,overview,replicate,audio}/1706.03762`, depending on the internal tab you're on. So I added the regexp to allow jumping from all of those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Alphaxiv URL handling to support overview, replicate, and audio pages.
  * These pages now redirect to the corresponding arXiv abstract page.

* **Tests**
  * Added navigation coverage for the newly supported Alphaxiv page types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->